### PR TITLE
Actualizadas versiones de agp y kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-agp = "8.12.3"
+agp = "8.13.0"
 gson = "2.13.2"
-kotlin = "2.0.21"
+kotlin = "2.2.20"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"


### PR DESCRIPTION
This pull request updates dependency versions in the `gradle/libs.versions.toml` file to keep the project up to date with the latest releases.

Dependency version updates:

* Upgraded the Android Gradle Plugin (`agp`) version from `8.12.3` to `8.13.0`.
* Upgraded the Kotlin version from `2.0.21` to `2.2.20`.

Closes #5 